### PR TITLE
feat: drop support for icecast 2.5-beta3

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -34,7 +34,6 @@ jobs:
       matrix:
         version:
           - 2.4.4
-          - 2.5-beta3
         variant:
           - debian
           - alpine

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSIONS =	2.4.4 2.5-beta3
+VERSIONS =	2.4.4
 TARBALLS = $(foreach version,$(VERSIONS),icecast-$(version).tar.gz)
 IMAGE = ghcr.io/libretime/icecast
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ The following icecast tags are supported:
 
 - `2.4.4-debian`, `2.4.4`, `debian`, `latest`
 - `2.4.4-alpine`, `alpine`
-- `2.5-beta3-debian`, `2.5-beta3`
-- `2.5-beta3-alpine`
+
+The following icecast tags are **not supported** anymore:
+
+- `2.5-beta3-debian`, `2.5-beta3` (since 2025/09/17)
+- `2.5-beta3-alpine` (since 2025/09/17)
 
 > If the underlying system packages or the base images are updated, a newer docker image will be build. The tags will always point to the newer images. To prevent unexpected images updates, we suggest you to pin the image by adding its sha256 digest, for example `2.4.4@sha256:56e6f265675f07a80c4164f48b2ed6f3d371aed78a334c666dd2eda0d97afc5e`.
 >


### PR DESCRIPTION
A new 2.5-rc1 version is available and the beta version did not build on newer version of alpine.