### PR TITLE
debian.dockerfile :: Update Debian base image and modify build process

### DIFF
--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -4,16 +4,17 @@
 FROM debian:trixie-slim@sha256:77ba0164de17b88dd0bf6cdc8f65569e6e5fa6cd256562998b62553134a00ef0 AS builder
 ARG VERSION
 
-RUN <<'EOF'
+RUN <<"EOF"
 set -eux
 export DEBIAN_FRONTEND=noninteractive
-apt-get update
+apt-get -y update
 apt-get install -y --no-install-recommends \
     autoconf \
     automake \
     build-essential \
     ca-certificates \
     curl \
+    git \
     libtool \
     make \
     pkg-config \
@@ -73,7 +74,7 @@ ARG VERSION
 RUN <<'EOF'
 set -eux
 export DEBIAN_FRONTEND=noninteractive
-apt-get update
+apt-get -y update
 apt-get install -y --no-install-recommends \
     ca-certificates \
     media-types \
@@ -83,7 +84,7 @@ apt-get install -y --no-install-recommends \
     libssl3t64 \
     libtheora0 \
     libvorbis0a \
-    libxml2 \
+    libxml2  \
     libxslt1.1 \
     librhash1
 rm -rf /var/lib/apt/lists/*

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -1,15 +1,19 @@
-FROM debian:trixie-slim@sha256:4bcb9db66237237d03b55b969271728dd3d955eaaa254b9db8a3db94550b1885 AS builder
+# =========================================================
+# Builder stage
+# =========================================================
+FROM debian:trixie-slim@sha256:77ba0164de17b88dd0bf6cdc8f65569e6e5fa6cd256562998b62553134a00ef0 AS builder
 ARG VERSION
 
-RUN <<"EOF"
+RUN <<'EOF'
 set -eux
 export DEBIAN_FRONTEND=noninteractive
-apt-get -y update
+apt-get update
 apt-get install -y --no-install-recommends \
+    autoconf \
     automake \
     build-essential \
     ca-certificates \
-    git \
+    curl \
     libtool \
     make \
     pkg-config \
@@ -21,32 +25,55 @@ apt-get install -y --no-install-recommends \
     libvorbis-dev \
     libxml2-dev \
     libxslt1-dev \
-    $(if [ $VERSION = "2.5.0" ]; then echo \
-    libigloo-dev \
-    librhash-dev \
-    ; fi)
+    librhash-dev
 rm -rf /var/lib/apt/lists/*
 EOF
 
+# ---------------------------------------------------------
+# Build and install libigloo 0.9.5 (required for Icecast 2.5)
+# ---------------------------------------------------------
+WORKDIR /tmp
+
+RUN curl -fsSL https://downloads.xiph.org/releases/igloo/libigloo-0.9.5.tar.gz \
+    | tar xz && \
+    cd libigloo-0.9.5 && \
+    ./configure --prefix=/usr && \
+    make -j$(nproc) && \
+    make install && \
+    ldconfig && \
+    rm -rf /tmp/libigloo-0.9.5
+
+# ---------------------------------------------------------
+# Build Icecast
+# ---------------------------------------------------------
 WORKDIR /build
 ADD icecast-$VERSION.tar.gz .
-RUN if test ! -d icecast-$VERSION; then mv icecast-* icecast-$VERSION; fi
+
+RUN if [ ! -d icecast-$VERSION ]; then \
+        mv icecast-* icecast-$VERSION ; \
+    fi
 
 WORKDIR /build/icecast-$VERSION
+
 RUN ./configure \
     --prefix=/usr \
     --sysconfdir=/etc \
     --localstatedir=/var
 
-RUN make
+RUN make -j$(nproc)
 RUN make install DESTDIR=/build/output
 
-FROM debian:trixie-slim@sha256:4bcb9db66237237d03b55b969271728dd3d955eaaa254b9db8a3db94550b1885
 
-RUN <<"EOF"
+# =========================================================
+# Runtime stage
+# =========================================================
+FROM debian:trixie-slim@sha256:77ba0164de17b88dd0bf6cdc8f65569e6e5fa6cd256562998b62553134a00ef0
+ARG VERSION
+
+RUN <<'EOF'
 set -eux
 export DEBIAN_FRONTEND=noninteractive
-apt-get -y update
+apt-get update
 apt-get install -y --no-install-recommends \
     ca-certificates \
     media-types \
@@ -56,32 +83,41 @@ apt-get install -y --no-install-recommends \
     libssl3t64 \
     libtheora0 \
     libvorbis0a \
-    libxml2  \
+    libxml2 \
     libxslt1.1 \
-    $(if [ $VERSION = "2.5.0" ]; then echo \
-    libigloo0t64 \
-    librhash1 \
-    ; fi)
+    librhash1
 rm -rf /var/lib/apt/lists/*
 EOF
 
+# ---------------------------------------------------------
+# Runtime user
+# ---------------------------------------------------------
 ENV USER=icecast
-
 RUN useradd --no-create-home $USER
 
+# ---------------------------------------------------------
+# Entrypoint tools
+# ---------------------------------------------------------
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint
 COPY xml-edit.sh /usr/local/bin/xml-edit
-RUN chmod +x \
-    /usr/local/bin/docker-entrypoint \
-    /usr/local/bin/xml-edit
+RUN chmod +x /usr/local/bin/docker-entrypoint /usr/local/bin/xml-edit
 
+# ---------------------------------------------------------
+# Icecast files
+# ---------------------------------------------------------
 COPY --from=builder /build/output /
+
+# ✅ REQUIRED: libigloo runtime library
+COPY --from=builder /usr/lib/libigloo.so* /usr/lib/
+RUN ldconfig
+
 RUN xml-edit errorlog - /etc/icecast.xml
 
 RUN mkdir -p /var/log/icecast && \
     chown $USER /etc/icecast.xml /var/log/icecast
 
 EXPOSE 8000
-ENTRYPOINT ["docker-entrypoint"]
+
 USER $USER
+ENTRYPOINT ["docker-entrypoint"]
 CMD ["icecast", "-c", "/etc/icecast.xml"]


### PR DESCRIPTION
Test Build:

We have manually built the Docker image on a Rocky Linux 9 VM using the following command:

docker build \
  --no-cache \
  --build-arg VERSION=2.5.0 \
  -f debian.dockerfile \
  -t icecast:2.5.0-rc1 .
